### PR TITLE
Change Process.Id to long

### DIFF
--- a/src/Transformalize/Configuration/Process.cs
+++ b/src/Transformalize/Configuration/Process.cs
@@ -703,8 +703,8 @@ namespace Transformalize.Configuration {
       /// <summary>
       /// An optional Id (used in Orchard CMS module)
       /// </summary>
-      [Cfg(value = 0)]
-      public int Id { get; set; }
+      [Cfg(value = (long)0)]
+      public long Id { get; set; }
 
       public void Dispose() {
          if (Preserve)


### PR DESCRIPTION
In the latest versions of Orchard Core the ContentItem.Id has been changed to long instead of int