### PR TITLE
Add line-ending option to the CsvHelper file provider

### DIFF
--- a/src/CLI/CLI.csproj
+++ b/src/CLI/CLI.csproj
@@ -9,9 +9,9 @@
       <Copyright>Copyright © 2013-2026 Dale Newman</Copyright>
       <PackageIcon>tfl.png</PackageIcon>
 
-      <Version>1.4.3</Version>
-      <FileVersion>1.4.3</FileVersion>
-      <AssemblyVersion>1.4.3</AssemblyVersion>
+      <Version>1.4.5</Version>
+      <FileVersion>1.4.5</FileVersion>
+      <AssemblyVersion>1.4.5</AssemblyVersion>
 
       <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
       <DockerfileContext>..\..</DockerfileContext>

--- a/src/Containers/Autofac/Autofac.csproj
+++ b/src/Containers/Autofac/Autofac.csproj
@@ -3,9 +3,9 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Transformalize.Container.Autofac</RootNamespace>
     <AssemblyName>Transformalize.Container.Autofac</AssemblyName>
-    <Version>1.4.4</Version>
-    <FileVersion>1.4.4</FileVersion>
-    <AssemblyVersion>1.4.4</AssemblyVersion>
+    <Version>1.4.5</Version>
+    <FileVersion>1.4.5</FileVersion>
+    <AssemblyVersion>1.4.5</AssemblyVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DefineConstants>TRACE</DefineConstants>

--- a/src/Providers/CsvHelper/Transformalize.Provider.CsvHelper.Autofac/Transformalize.Provider.CsvHelper.Autofac.csproj
+++ b/src/Providers/CsvHelper/Transformalize.Provider.CsvHelper.Autofac/Transformalize.Provider.CsvHelper.Autofac.csproj
@@ -3,19 +3,19 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Transformalize.Providers.CsvHelper.Autofac</RootNamespace>
     <Title>Transformalize File Provider using CsvHelper Autofac Module</Title>
-    <Version>1.0.0</Version>
+    <Version>1.4.5</Version>
     <Authors>Dale Newman</Authors>
     <Company>Transformalize</Company>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Description>An Autofac module for Transformalize.Providers.CsvHelper.</Description>
-    <Copyright>Copyright © 2018-2025 Dale Newman</Copyright>
+    <Copyright>Copyright © 2018-2026 Dale Newman</Copyright>
     <PackageProjectUrl>https://github.com/dalenewman/Transformalize.Provider.CsvHelper</PackageProjectUrl>
     <RepositoryUrl>https://github.com/dalenewman/Transformalize.Provider.CsvHelper.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>etl,csvhelper,transformalize,csv</PackageTags>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <FileVersion>1.0.0</FileVersion>
-    <AssemblyVersion>1.0.0</AssemblyVersion>
+    <FileVersion>1.4.5</FileVersion>
+    <AssemblyVersion>1.4.5</AssemblyVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Containers\Autofac\Autofac.csproj" />

--- a/src/Providers/CsvHelper/Transformalize.Provider.CsvHelper/CsvHelperCommon.cs
+++ b/src/Providers/CsvHelper/Transformalize.Provider.CsvHelper/CsvHelperCommon.cs
@@ -18,7 +18,7 @@ namespace Transformalize.Providers.CsvHelper {
          Config = new CsvConfiguration(System.Globalization.CultureInfo.CurrentCulture) {
             Delimiter = string.IsNullOrEmpty(_context.Connection.Delimiter) ? "," : _context.Connection.Delimiter,
             IgnoreBlankLines = true,
-            NewLine = Environment.NewLine
+            NewLine = GetNewLine(_context.Connection.LineEnding)
          };
 
          if (!string.IsNullOrEmpty(_context.Connection.TextQualifier)) {
@@ -26,6 +26,17 @@ namespace Transformalize.Providers.CsvHelper {
          }
          Config.Encoding = Encoding.GetEncoding(_context.Connection.Encoding);
          Config.TrimOptions = TrimOptions.None;
+      }
+
+      private static string GetNewLine(string lineEnding) {
+         switch (lineEnding) {
+            case "crlf":
+               return "\r\n";
+            case "lf":
+               return "\n";
+            default:
+               return Environment.NewLine;
+         }
       }
       public void WriteHeader(CsvWriter writer) {
          foreach (var field in _context.OutputFields) {

--- a/src/Providers/CsvHelper/Transformalize.Provider.CsvHelper/Transformalize.Provider.CsvHelper.csproj
+++ b/src/Providers/CsvHelper/Transformalize.Provider.CsvHelper/Transformalize.Provider.CsvHelper.csproj
@@ -3,19 +3,19 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Transformalize.Providers.CsvHelper</RootNamespace>
     <Title>Transformalize File Provider using CsvHelper Autofac Module</Title>
-    <Version>1.0.0</Version>
+    <Version>1.4.5</Version>
     <Authors>Dale Newman</Authors>
     <Company>Transformalize</Company>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Description>A Transformalize provider using CsvHelper for reading and writing files.</Description>
-    <Copyright>Copyright © 2020-2025 Dale Newman</Copyright>
+    <Copyright>Copyright © 2020-2026 Dale Newman</Copyright>
     <PackageProjectUrl>https://github.com/dalenewman/Transformalize.Provider.CsvHelper</PackageProjectUrl>
     <RepositoryUrl>https://github.com/dalenewman/Transformalize.Provider.CsvHelper.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>etl,csvhelper,transformalize,csv</PackageTags>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <FileVersion>1.0.0</FileVersion>
-    <AssemblyVersion>1.0.0</AssemblyVersion>
+    <FileVersion>1.4.5</FileVersion>
+    <AssemblyVersion>1.4.5</AssemblyVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CsvHelper" Version="33.1.0" />

--- a/src/Transformalize/Configuration/Connection.cs
+++ b/src/Transformalize/Configuration/Connection.cs
@@ -50,6 +50,12 @@ namespace Transformalize.Configuration {
       [Cfg(value = "")]
       public string Delimiter { get; set; }
 
+      /// <summary>
+      /// Line ending used when writing delimited files: environment (default), crlf, or lf
+      /// </summary>
+      [Cfg(value = "environment", domain = "environment,crlf,lf", toLower = true, ignoreCase = true)]
+      public string LineEnding { get; set; }
+
       [Cfg(value = 1)]
       public int MaxDegreeOfParallelism { get; set; }
 

--- a/src/Transformalize/ConfigurationFacade/Connection.cs
+++ b/src/Transformalize/ConfigurationFacade/Connection.cs
@@ -233,6 +233,9 @@ namespace Transformalize.ConfigurationFacade {
       [Cfg]
       public string Browse { get; set; }
 
+      [Cfg]
+      public string LineEnding { get; set; }
+
       public Configuration.Connection ToConnection() {
          var c = new Configuration.Connection {
             Arguments = this.Arguments,
@@ -281,7 +284,8 @@ namespace Transformalize.ConfigurationFacade {
             WebMethod = this.WebMethod,
             Scroll = this.Scroll,
             Service = this.Service,
-            CertificateFingerprint = this.CertificateFingerprint
+            CertificateFingerprint = this.CertificateFingerprint,
+            LineEnding = this.LineEnding
          };
 
          bool.TryParse(this.Buffer, out bool buffer);

--- a/src/Transformalize/Transformalize.csproj
+++ b/src/Transformalize/Transformalize.csproj
@@ -3,9 +3,9 @@
       <TargetFramework>netstandard2.0</TargetFramework>
       <RootNamespace>Transformalize</RootNamespace>
       <AssemblyName>Transformalize</AssemblyName>
-      <Version>1.4.4</Version>
-      <FileVersion>1.4.4</FileVersion>
-      <AssemblyVersion>1.4.4</AssemblyVersion>
+      <Version>1.4.5</Version>
+      <FileVersion>1.4.5</FileVersion>
+      <AssemblyVersion>1.4.5</AssemblyVersion>
       <NeutralLanguage>en-US</NeutralLanguage>
       <Copyright>Copyright © 2013-2026 Dale Newman</Copyright>
       <Authors>Dale Newman</Authors>

--- a/test/Test.Unit.CsvHelper/LineEnding.cs
+++ b/test/Test.Unit.CsvHelper/LineEnding.cs
@@ -1,0 +1,61 @@
+using Autofac;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
+using System.Linq;
+using Transformalize.Configuration;
+using Transformalize.Containers.Autofac;
+using Transformalize.Contracts;
+using Transformalize.Providers.Bogus.Autofac;
+using Transformalize.Providers.Console;
+using Transformalize.Providers.CsvHelper.Autofac;
+
+namespace Test.Integration.Core {
+
+   [TestClass]
+   public class LineEnding {
+
+      [TestMethod]
+      public void WriteCrlf() {
+         var text = WriteWithLineEnding("crlf", "files/bogus-crlf.csv");
+         Assert.AreEqual(11, text.Count(c => c == '\n'), "header + 10 rows");
+         Assert.AreEqual(11, text.Split(new[] { "\r\n" }, System.StringSplitOptions.None).Length - 1, "every line ends with crlf");
+      }
+
+      [TestMethod]
+      public void WriteLf() {
+         var text = WriteWithLineEnding("lf", "files/bogus-lf.csv");
+         Assert.AreEqual(11, text.Count(c => c == '\n'), "header + 10 rows");
+         Assert.IsFalse(text.Contains('\r'), "no carriage returns");
+      }
+
+      private static string WriteWithLineEnding(string lineEnding, string file) {
+
+         string xml = $@"<add name='file' read-only='true'>
+  <connections>
+    <add name='input' provider='bogus' seed='1' />
+    <add name='output' provider='file' delimiter=',' line-ending='{lineEnding}' file='{file}' />
+  </connections>
+  <entities>
+    <add name='Contact' size='10'>
+      <fields>
+        <add name='Identity' type='int' />
+        <add name='FirstName' />
+        <add name='LastName' />
+      </fields>
+    </add>
+  </entities>
+</add>";
+
+         var logger = new ConsoleLogger(LogLevel.Info);
+         using (var outer = new ConfigurationContainer().CreateScope(xml, logger)) {
+            var process = outer.Resolve<Process>();
+            using (var inner = new Container(new BogusModule(), new CsvHelperProviderModule()).CreateScope(process, logger)) {
+               var controller = inner.Resolve<IProcessController>();
+               controller.Execute();
+            }
+         }
+
+         return File.ReadAllText(file);
+      }
+   }
+}


### PR DESCRIPTION
The csv writer currently hardcodes `NewLine = Environment.NewLine`, so a process hosted on Linux/macOS always emits LF — there's no way to produce RFC 4180 CRLF output for Excel-centric consumers without post-processing the stream.

This adds an optional `line-ending` attribute on the connection (`environment` | `crlf` | `lf`, default `environment`), used by `CsvHelperWriterBase` when configuring the writer. Default behavior is unchanged; reading is unaffected since CsvHelper auto-detects line endings on input.

```xml
<add name="output" provider="file" delimiter="," line-ending="crlf" file="report.csv" />
```

Includes unit tests for both explicit endings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)